### PR TITLE
Refactor signatures and document usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,3 +20,15 @@ solid performance.
 The authors and contributors of this project do not endorse or encourage cheating or bypassing game security mechanisms. Any use of the code in this repository that violates the terms of service of games, software, or platforms is the sole responsibility of the user.
 
 You are fully responsible for any consequences, including account bans or other penalties, that may result from the use of this code.
+
+## Offset Signatures
+
+The offset finder relies on *signatures*—unique byte patterns in the game's modules—to locate
+important memory addresses such as the entity list or camera manager. These patterns are
+defined in [`signature_patterns.py`](signature_patterns.py) and consumed by
+`offset_finder.py` when scanning the running process.
+
+If Valve updates Deadlock and the underlying code changes, these patterns may no longer match.
+Outdated signatures will result in missing or incorrect offsets, causing other tools in this
+repository to malfunction. When that happens, the signatures need to be updated by scanning the
+new game binaries for the correct patterns.

--- a/offset_finder.py
+++ b/offset_finder.py
@@ -10,6 +10,8 @@ from typing import Dict, Optional
 
 import psutil
 
+from signature_patterns import SIGNATURES as SIGNATURE_PATTERNS
+
 # Define Windows API constants
 PROCESS_QUERY_INFORMATION = 0x0400
 PROCESS_VM_READ = 0x0010
@@ -132,15 +134,8 @@ def read_process_memory(handle: wintypes.HANDLE, address: int, size: int) -> byt
 def find_offsets(process_name: str) -> Dict[str, int]:
     """Scan ``process_name`` for known signatures and return their offsets."""
     sigs = {
-        "local_player_controller": Signature("48 8B 1D ? ? ? ? 48 8B 6C 24", 3, 7),
-        "view_matrix": Signature("48 8D ? ? ? ? ? 48 C1 E0 06 48 03 C1 C3", 3, 7),
-        "entity_list": Signature("48 8B 0D ? ? ? ? C7 45 0F C8 00 00 00", 3, 7),
-        "camera_manager": Signature("48 8D 3D ? ? ? ? 8B D9", 3, 7),
-        "schema_system_interface": Signature(
-            "48 89 05 ? ? ? ? 4C 8D 0D ? ? ? ? 0F B6 45 E8 4C 8D 45 E0 33 F6",
-            3,
-            7,
-        ),
+        name: Signature(pattern, offset, extra)
+        for name, (pattern, offset, extra) in SIGNATURE_PATTERNS.items()
     }
 
     handle = get_process_handle(process_name)

--- a/signature_patterns.py
+++ b/signature_patterns.py
@@ -1,0 +1,30 @@
+"""Signature patterns for Deadlock offset scanning."""
+
+# Mapping of offset names to (pattern, offset, extra)
+SIGNATURES = {
+    "local_player_controller": (
+        "48 8B 1D ? ? ? ? 48 8B 6C 24",
+        3,
+        7,
+    ),
+    "view_matrix": (
+        "48 8D ? ? ? ? ? 48 C1 E0 06 48 03 C1 C3",
+        3,
+        7,
+    ),
+    "entity_list": (
+        "48 8B 0D ? ? ? ? C7 45 0F C8 00 00 00",
+        3,
+        7,
+    ),
+    "camera_manager": (
+        "48 8D 3D ? ? ? ? 8B D9",
+        3,
+        7,
+    ),
+    "schema_system_interface": (
+        "48 89 05 ? ? ? ? 4C 8D 0D ? ? ? ? 0F B6 45 E8 4C 8D 45 E0 33 F6",
+        3,
+        7,
+    ),
+}


### PR DESCRIPTION
## Summary
- extract signature patterns into `signature_patterns.py`
- import signature patterns in `offset_finder.py`
- document how signatures work and the implications of outdated patterns in the README

## Testing
- `python -m py_compile offset_finder.py signature_patterns.py`

------
https://chatgpt.com/codex/tasks/task_e_68408836bc04832d9683f2a4c1dee9ff