### PR TITLE
Add logging and debug CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,12 @@ python -m deadlock.aimbot
 ```
 
 The script connects to the game's process and continually adjusts your camera
-towards enemy targets.
+towards enemy targets. By default only basic setup messages are shown. Pass
+``--debug`` to enable verbose logging about target changes and aimbot state:
+
+```bash
+python -m deadlock.aimbot --debug
+```
 
 ### ESP Overlay
 

--- a/deadlock/aimbot.py
+++ b/deadlock/aimbot.py
@@ -12,6 +12,7 @@ relies on ``win32api`` to query mouse button state.
 """
 
 from dataclasses import dataclass
+import logging
 import random
 import time
 
@@ -44,13 +45,15 @@ class AimbotSettings:
 
 class Aimbot:
     """Basic aimbot controller."""
-    
+
     def __init__(self, mem: DeadlockMemory, settings: AimbotSettings | None = None) -> None:
         """Create a new aimbot bound to ``mem``."""
-        
+
         self.mem = mem
         self.settings = settings or AimbotSettings()
         self.locked_on: int | None = None
+        self.log = logging.getLogger(self.__class__.__name__)
+        self.log.info("Aimbot initialised with settings: %s", self.settings)
 
     def should_aim_for_head(self) -> bool:
         """Return ``True`` if the bot should attempt a headshot."""
@@ -59,11 +62,13 @@ class Aimbot:
 
     def run(self) -> None:
         """Main aimbot loop."""
-
+        self.log.info("Starting aimbot loop")
         while True:
             # Only run aimbot when left mouse button is held down
             if win32api.GetKeyState(0x01) >= 0:
                 # Left mouse button is not held down, reset target and continue
+                if self.locked_on is not None:
+                    self.log.debug("Aimbot deactivated")
                 self.locked_on = None
                 time.sleep(0.01)
                 continue
@@ -98,6 +103,8 @@ class Aimbot:
                         if best_score is None or score < best_score:
                             best_score = score
                             target_idx = i
+                if target_idx is not None:
+                    self.log.debug("Locked on to target index %s", target_idx)
                 self.locked_on = target_idx
 
             if self.locked_on is None:
@@ -107,6 +114,7 @@ class Aimbot:
             try:
                 target = self.mem.read_entity(self.locked_on)
             except Exception:
+                self.log.debug("Lost target %s", self.locked_on)
                 self.locked_on = None
                 continue
 
@@ -138,7 +146,24 @@ class Aimbot:
             time.sleep(0.001)
 
 
-def main() -> None:
+def main(argv: list[str] | None = None) -> None:
+    """Entry point for the aimbot CLI."""
+
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Deadlock aimbot")
+    parser.add_argument(
+        "--debug",
+        action="store_true",
+        help="Enable debug logging",
+    )
+    args = parser.parse_args(argv)
+
+    logging.basicConfig(
+        level=logging.DEBUG if args.debug else logging.INFO,
+        format="%(asctime)s [%(levelname)s] %(message)s",
+    )
+
     mem = DeadlockMemory()
     bot = Aimbot(mem)
     bot.run()

--- a/deadlock/esp.py
+++ b/deadlock/esp.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 """Simplistic ESP (Extra Sensory Perception) overlay using pygame."""
 
 import ctypes
+import logging
 import time
 
 import numpy as np
@@ -19,6 +20,7 @@ class ESP:
         """Create an overlay bound to ``mem``."""
 
         self.mem = mem
+        self.log = logging.getLogger(self.__class__.__name__)
         pygame.init()
         info = pygame.display.Info()
         self.screen = pygame.display.set_mode((info.current_w, info.current_h), pygame.NOFRAME | pygame.SRCALPHA)
@@ -28,6 +30,7 @@ class ESP:
         hwnd = pygame.display.get_wm_info()["window"]
         ctypes.windll.user32.SetWindowLongW(hwnd, -20, ctypes.windll.user32.GetWindowLongW(hwnd, -20) | 0x80000 | 0x20)
         ctypes.windll.user32.SetLayeredWindowAttributes(hwnd, 0, 255, 1)
+        self.log.info("ESP overlay initialised: %sx%s", info.current_w, info.current_h)
 
     def draw_skeleton(self, bones, color=(255, 0, 0)) -> None:
         """Draw a list of bone pairs to the screen."""
@@ -52,7 +55,7 @@ class ESP:
 
     def run(self) -> None:
         """Main overlay loop."""
-
+        self.log.info("Starting ESP overlay loop")
         running = True
         while running:
             self.screen.fill((0, 0, 0, 0))
@@ -82,6 +85,7 @@ class ESP:
 
 
 def main() -> None:
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(levelname)s] %(message)s")
     mem = DeadlockMemory()
     esp = ESP(mem)
     esp.run()


### PR DESCRIPTION
## Summary
- add info/debug logging to aimbot and esp modules
- expose `--debug` CLI option for the aimbot
- document debug usage in README

## Testing
- `pip install -q psutil pygame` *(fails: pywin32 unavailable)*
- `python -m deadlock.aimbot --help` *(fails: platform dependencies missing)*

------
https://chatgpt.com/codex/tasks/task_e_68408d59bd4c832d86756536ebbcfcfc