### PR TITLE
Add hero ability lock settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,13 @@ python -m deadlock.aimbot
 The script connects to the game's process and continually adjusts your camera
 towards enemy targets.
 
+#### Hero ability lock
+
+When playing **Grey Talon** or **Yamato**, pressing **Q** (ability 1) keeps the
+aimbot locked on your target for a short duration. Using **Vindicta's** **R**
+(ability 4) triggers the same lock. These timeouts can be changed through
+``AimbotSettings`` (`grey_talon_lock`, `yamato_lock`, and `vindicta_lock`).
+
 ### ESP Overlay
 
 To render a simple ESP overlay showing player skeletons, run:


### PR DESCRIPTION
## Summary
- support hero-specific ability locks in the aimbot
- document ability lock behaviour and keybinds

## Testing
- `python -m py_compile deadlock/*.py offset_finder.py`

------
https://chatgpt.com/codex/tasks/task_e_68408dffb908832da682ed8da86ff496