### PR TITLE
Add note on ESP overlay for bone IDs

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,3 +64,8 @@ python -m deadlock.esp
 
 This spawns a transparent Pygame window that follows the game and updates in
 real time.
+
+The overlay is also handy for discovering bone indexes for each hero. When
+Valve updates a character model, running it lets you read the new bone numbers
+and update the head and body mappings stored in
+[`deadlock/heroes.py`](deadlock/heroes.py).


### PR DESCRIPTION
## Summary
- mention that the ESP overlay can be used to capture hero bone indexes
- link to the heroes.py file that stores bone IDs

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68408e41e9d4832dbded446db0099bc6