### PR TITLE
Reorder README headings

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,6 @@
 
 Aimbot and ESP for Valve's Deadlock game.
 
-## Note
-
-This repository is provided for educational and research purposes only. Use it at your own risk.
-
 ## About
 
 This project started as a personal learning exercise to better understand game
@@ -15,23 +11,15 @@ reads from and writes directly into the game's memory. The entire codebase is
 written in Python for maximum readability while still offering surprisingly
 solid performance.
 
+## Note
+
+This repository is provided for educational and research purposes only. Use it at your own risk.
+
 ## Disclaimer
 
 The authors and contributors of this project do not endorse or encourage cheating or bypassing game security mechanisms. Any use of the code in this repository that violates the terms of service of games, software, or platforms is the sole responsibility of the user.
 
 You are fully responsible for any consequences, including account bans or other penalties, that may result from the use of this code.
-
-## Offset Signatures
-
-The offset finder relies on *signatures*—unique byte patterns in the game's modules—to locate
-important memory addresses such as the entity list or camera manager. These patterns are
-defined in [`signature_patterns.py`](signature_patterns.py) and consumed by
-`offset_finder.py` when scanning the running process.
-
-If Valve updates Deadlock and the underlying code changes, these patterns may no longer match.
-Outdated signatures will result in missing or incorrect offsets, causing other tools in this
-repository to malfunction. When that happens, the signatures need to be updated by scanning the
-new game binaries for the correct patterns.
 
 ## Running the Tools
 
@@ -79,3 +67,15 @@ The overlay is also handy for discovering bone indexes for each hero. When
 Valve updates a character model, running it lets you read the new bone numbers
 and update the head and body mappings stored in
 [`deadlock/heroes.py`](deadlock/heroes.py).
+
+## Offset Signatures
+
+The offset finder relies on *signatures*—unique byte patterns in the game's modules—to locate
+important memory addresses such as the entity list or camera manager. These patterns are
+defined in [`signature_patterns.py`](signature_patterns.py) and consumed by
+`offset_finder.py` when scanning the running process.
+
+If Valve updates Deadlock and the underlying code changes, these patterns may no longer match.
+Outdated signatures will result in missing or incorrect offsets, causing other tools in this
+repository to malfunction. When that happens, the signatures need to be updated by scanning the
+new game binaries for the correct patterns.


### PR DESCRIPTION
## Summary
- move **About** to the top of the README
- place **Offset Signatures** after tool usage info

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6840961d53e8832da03bbb1bdb3907e1