### PR TITLE
Add logging and debug CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,13 @@ python -m deadlock.aimbot
 ```
 
 The script connects to the game's process and continually adjusts your camera
-towards enemy targets.
+towards enemy targets. When run normally it prints only setup information.
+Pass ``--debug`` to enable verbose logging about target changes and aimbot
+state:
+
+```bash
+python -m deadlock.aimbot --debug
+```
 
 ### ESP Overlay
 

--- a/deadlock/__init__.py
+++ b/deadlock/__init__.py
@@ -1,9 +1,8 @@
 """Helper package exposing a minimal Deadlock API."""
 
-from .memory import DeadlockMemory
-from .aimbot import Aimbot, AimbotSettings
-from .esp import ESP
-from .heroes import HeroIds
+from __future__ import annotations
+
+import importlib
 
 __all__ = [
     "DeadlockMemory",
@@ -12,3 +11,19 @@ __all__ = [
     "ESP",
     "HeroIds",
 ]
+
+_MODULES: dict[str, str] = {
+    "DeadlockMemory": "memory",
+    "Aimbot": "aimbot",
+    "AimbotSettings": "aimbot",
+    "ESP": "esp",
+    "HeroIds": "heroes",
+}
+
+
+def __getattr__(name: str):
+    module_name = _MODULES.get(name)
+    if module_name is None:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    module = importlib.import_module(f".{module_name}", __name__)
+    return getattr(module, name)

--- a/deadlock/esp.py
+++ b/deadlock/esp.py
@@ -3,13 +3,24 @@ from __future__ import annotations
 """Simplistic ESP (Extra Sensory Perception) overlay using pygame."""
 
 import ctypes
+import logging
 import time
 
 import numpy as np
 import pygame
 
-from .helpers import world_to_screen
-from .memory import DeadlockMemory
+try:
+    from .helpers import world_to_screen
+    from .memory import DeadlockMemory
+    _IMPORT_ERROR: Exception | None = None
+except Exception as exc:
+    try:  # pragma: no cover - used when running directly
+        from helpers import world_to_screen
+        from memory import DeadlockMemory
+    except Exception as inner:
+        _IMPORT_ERROR = inner
+    else:
+        _IMPORT_ERROR = exc
 
 
 class ESP:
@@ -19,6 +30,7 @@ class ESP:
         """Create an overlay bound to ``mem``."""
 
         self.mem = mem
+        self.log = logging.getLogger(self.__class__.__name__)
         pygame.init()
         info = pygame.display.Info()
         self.screen = pygame.display.set_mode((info.current_w, info.current_h), pygame.NOFRAME | pygame.SRCALPHA)
@@ -28,6 +40,7 @@ class ESP:
         hwnd = pygame.display.get_wm_info()["window"]
         ctypes.windll.user32.SetWindowLongW(hwnd, -20, ctypes.windll.user32.GetWindowLongW(hwnd, -20) | 0x80000 | 0x20)
         ctypes.windll.user32.SetLayeredWindowAttributes(hwnd, 0, 255, 1)
+        self.log.info("ESP overlay initialised: %sx%s", info.current_w, info.current_h)
 
     def draw_skeleton(self, bones, color=(255, 0, 0)) -> None:
         """Draw a list of bone pairs to the screen."""
@@ -52,7 +65,7 @@ class ESP:
 
     def run(self) -> None:
         """Main overlay loop."""
-
+        self.log.info("Starting ESP overlay loop")
         running = True
         while running:
             self.screen.fill((0, 0, 0, 0))
@@ -82,6 +95,11 @@ class ESP:
 
 
 def main() -> None:
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(levelname)s] %(message)s")
+
+    if _IMPORT_ERROR is not None:
+        raise SystemExit(f"Required Windows-only dependencies not available: {_IMPORT_ERROR}")
+
     mem = DeadlockMemory()
     esp = ESP(mem)
     esp.run()


### PR DESCRIPTION
## Summary
- add info/debug logging to aimbot and esp modules
- expose `--debug` CLI option for the aimbot
- document debug usage in README
- make module imports lazy so help works without Windows-only deps

## Testing
- `pip install -q psutil pygame`
- `python -m deadlock.aimbot --help | head`


------
https://chatgpt.com/codex/tasks/task_e_68408d59bd4c832d86756536ebbcfcfc