### PR TITLE
Add debug logging and CLI flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,12 @@ python -m deadlock.aimbot
 The script connects to the game's process and continually adjusts your camera
 towards enemy targets.
 
+Add ``--debug`` to enable verbose logging useful for troubleshooting:
+
+```bash
+python -m deadlock.aimbot --debug
+```
+
 #### Hero ability lock
 
 When playing **Grey Talon** or **Yamato**, pressing **Q** (ability 1) keeps the

--- a/deadlock/__init__.py
+++ b/deadlock/__init__.py
@@ -1,8 +1,6 @@
 """Helper package exposing a minimal Deadlock API."""
 
 from .memory import DeadlockMemory
-from .aimbot import Aimbot, AimbotSettings
-from .esp import ESP
 from .heroes import HeroIds
 
 __all__ = [
@@ -12,3 +10,18 @@ __all__ = [
     "ESP",
     "HeroIds",
 ]
+
+
+def __getattr__(name):
+    """Lazily import heavy modules only when accessed."""
+
+    if name in {"Aimbot", "AimbotSettings"}:
+        from .aimbot import Aimbot, AimbotSettings
+        globals()["Aimbot"] = Aimbot
+        globals()["AimbotSettings"] = AimbotSettings
+        return globals()[name]
+    if name == "ESP":
+        from .esp import ESP
+        globals()["ESP"] = ESP
+        return ESP
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")


### PR DESCRIPTION
## Summary
- add lazy attribute loader to the package init
- add info/debug logging to the aimbot and ESP modules
- make aimbot import `win32api` lazily and expose `--debug` flag
- make ESP import `pygame` lazily
- document debug usage in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6840973654e8832dadfd9fd659747fed