### PR TITLE
Add persistent GUI settings and exe packaging docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,3 +90,21 @@ If Valve updates Deadlock and the underlying code changes, these patterns may no
 Outdated signatures will result in missing or incorrect offsets, causing other tools in this
 repository to malfunction. When that happens, the signatures need to be updated by scanning the
 new game binaries for the correct patterns.
+
+## Building a standalone executable
+
+You can package the GUI into a single Windows executable using
+[PyInstaller](https://pyinstaller.org/). Install it first:
+
+```bash
+pip install pyinstaller
+```
+
+Then create the executable with:
+
+```bash
+pyinstaller --onefile deadlock/aimbot_gui.py
+```
+
+The resulting `.exe` will be placed in the `dist` folder and can be run on
+machines without Python installed.


### PR DESCRIPTION
## Summary
- remember user settings between GUI launches
- document how to create a standalone executable using PyInstaller

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68409ea02e7c832db3dcdc7f9d359e98