### PR TITLE
Add debug flag to aimbot and esp

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,13 @@ Launch Deadlock first and then start the aimbot with:
 python -m deadlock.aimbot
 ```
 
+Pass ``--debug`` to print detailed log messages which can help when
+troubleshooting:
+
+```bash
+python -m deadlock.aimbot --debug
+```
+
 The script connects to the game's process and continually adjusts your camera
 towards enemy targets.
 
@@ -69,6 +76,12 @@ To render a simple ESP overlay showing player skeletons, run:
 
 ```bash
 python -m deadlock.esp
+```
+
+To get verbose output while the overlay runs, add ``--debug``:
+
+```bash
+python -m deadlock.esp --debug
 ```
 
 This spawns a transparent Pygame window that follows the game and updates in

--- a/deadlock/aimbot.py
+++ b/deadlock/aimbot.py
@@ -15,6 +15,7 @@ from dataclasses import dataclass
 import random
 import time
 import logging
+import argparse
 
 import win32api
 
@@ -208,9 +209,26 @@ class Aimbot:
             time.sleep(0.001)
 
 
-def main() -> None:
+def main(argv: list[str] | None = None) -> None:
+    """Run the aimbot entry point.
+
+    Parameters
+    ----------
+    argv:
+        Optional command line arguments.  Providing ``--debug`` enables
+        verbose output.
+    """
+
+    parser = argparse.ArgumentParser(description="Deadlock aimbot")
+    parser.add_argument(
+        "--debug",
+        action="store_true",
+        help="enable debug logging",
+    )
+    args = parser.parse_args(argv)
+
     logging.basicConfig(
-        level=logging.INFO,
+        level=logging.DEBUG if args.debug else logging.INFO,
         format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
     )
     ensure_up_to_date()

--- a/deadlock/esp.py
+++ b/deadlock/esp.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import ctypes
 import time
 import logging
+import argparse
 
 import numpy as np
 import pygame
@@ -103,9 +104,26 @@ class ESP:
         logger.info("ESP loop stopped")
 
 
-def main() -> None:
+def main(argv: list[str] | None = None) -> None:
+    """Run the ESP overlay entry point.
+
+    Parameters
+    ----------
+    argv:
+        Optional command line arguments.  Providing ``--debug`` enables
+        verbose logging output.
+    """
+
+    parser = argparse.ArgumentParser(description="Deadlock ESP overlay")
+    parser.add_argument(
+        "--debug",
+        action="store_true",
+        help="enable debug logging",
+    )
+    args = parser.parse_args(argv)
+
     logging.basicConfig(
-        level=logging.INFO,
+        level=logging.DEBUG if args.debug else logging.INFO,
         format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
     )
     ensure_up_to_date()


### PR DESCRIPTION
## Summary
- allow running aimbot/esp with `--debug` to get verbose logs
- document the new CLI option in the README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68409fd7e6a8832d884e5c5f79f2137b