### PR TITLE
Add automated GUI release workflow

### DIFF
--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -1,0 +1,38 @@
+name: Build GUI and create release
+
+on:
+  push:
+    branches: ["**"]
+
+jobs:
+  build:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install pyinstaller
+
+      - name: Build executable
+        run: |
+          pyinstaller --onefile deadlock/aimbot_gui.py
+
+      - name: Get tag name
+        id: vars
+        run: echo "tag=build-${{ github.sha }}" >> $env:GITHUB_OUTPUT
+
+      - name: Create GitHub release
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: ${{ steps.vars.outputs.tag }}
+          name: ${{ steps.vars.outputs.tag }}
+          files: dist/aimbot_gui.exe
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_API_TOKEN }}


### PR DESCRIPTION
## Summary
- add a workflow that builds the aimbot GUI with PyInstaller on each push
- automatically create a GitHub release for each build

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6840a14c10c0832da54f7cf73814573f