### PR TITLE
Add right-click fire mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,11 @@ python -m deadlock.aimbot --debug
 The script connects to the game's process and continually adjusts your camera
 towards enemy targets.
 
+The aimbot automatically selects the closest target when you hold down the left
+mouse button. If you want to shoot without the aimbot—for example at troopers,
+towers or souls—hold the right mouse button instead and make sure to remap the
+alternate fire key in Deadlock's settings so it doesn't conflict.
+
 #### Hero ability lock
 
 When playing **Grey Talon** or **Yamato**, pressing **Q** (ability 1) keeps the

--- a/deadlock/aimbot.py
+++ b/deadlock/aimbot.py
@@ -16,6 +16,7 @@ import random
 import time
 import logging
 import argparse
+import ctypes
 
 import win32api
 
@@ -114,9 +115,22 @@ class Aimbot:
         logger.info("Aimbot loop started")
         active = False
         prev_locked = None
+        hold_down_left_click = False
         while True:
             my_data = self.mem.read_entity(0)
             self._update_ability_lock(my_data["hero"])
+
+            if not hold_down_left_click and win32api.GetKeyState(0x02) < 0:
+                hold_down_left_click = True
+                ctypes.windll.user32.mouse_event(2, 0, 0, 0, 0)
+
+            if hold_down_left_click and win32api.GetKeyState(0x02) >= 0:
+                hold_down_left_click = False
+                ctypes.windll.user32.mouse_event(4, 0, 0, 0, 0)
+
+            if hold_down_left_click:
+                time.sleep(0.01)
+                continue
 
             mouse_down = win32api.GetKeyState(0x01) < 0 or time.time() < self.force_aim_until
             if mouse_down != active:


### PR DESCRIPTION
## Summary
- hold left mouse when right mouse is pressed and pause aiming
- document new behaviour about target selection and right-click shooting

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6840ab0a7384832d9891cb38151ea0a0