### PR TITLE
Fix update restart

### DIFF
--- a/deadlock/aimbot_gui.py
+++ b/deadlock/aimbot_gui.py
@@ -132,10 +132,14 @@ class AimbotApp:
                     return
                 
                 # Start the actual update process
-                ensure_up_to_date(progress_callback, force=force, cancel_check=lambda: progress_dialog.cancelled)
+                ensure_up_to_date(
+                    progress_callback,
+                    force=force,
+                    cancel_check=lambda: progress_dialog.cancelled,
+                )
             except SystemExit:
-                # Expected when update completes successfully
-                pass
+                # Terminate entire application so the helper can replace the binary
+                os._exit(0)
             except Exception as e:
                 progress_callback(f"Update failed: {str(e)}")
                 progress_dialog.enable_close()


### PR DESCRIPTION
## Summary
- exit the entire app when update completes so helper can replace the binary

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6840d4092964832d970e8e1f53e6efde