### PR TITLE
Fix binary import error

### DIFF
--- a/deadlock/__init__.py
+++ b/deadlock/__init__.py
@@ -1,14 +1,27 @@
-"""Helper package exposing a minimal Deadlock API."""
+"""Public API for interacting with Deadlock.
+
+The heavy ESP module depends on :mod:`numpy` which is not required by the
+aimbot.  To keep binary start-up lightweight, it is imported lazily on first
+access.
+"""
 
 from .memory import DeadlockMemory
 from .aimbot import Aimbot, AimbotSettings
-from .esp import ESP
 from .heroes import HeroIds
 
 __all__ = [
     "DeadlockMemory",
     "Aimbot",
     "AimbotSettings",
-    "ESP",
     "HeroIds",
+    "ESP",
 ]
+
+
+def __getattr__(name: str):
+    """Lazily import optional modules on demand."""
+    if name == "ESP":
+        from .esp import ESP
+
+        return ESP
+    raise AttributeError(name)


### PR DESCRIPTION
## Summary
- avoid importing `esp` eagerly to keep numpy optional

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6840da9e8278832da043fae569e4f4e2