### PR TITLE
Add headshot-on-acquire setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,10 @@ the head or body, it will maintain that targeting preference for the next 0.4
 seconds before making a new random decision. This prevents rapid switching
 between head and body targeting that could appear unnatural.
 
+If no enemy has been targeted for more than two seconds, the
+`headshot_on_acquire` setting (enabled by default) forces headshots for the next
+0.4 seconds when a new target is acquired.
+
 #### Hero ability lock
 
 When playing **Grey Talon** or **Yamato**, pressing **Q** (ability 1) keeps the

--- a/deadlock/aimbot_gui.py
+++ b/deadlock/aimbot_gui.py
@@ -139,6 +139,13 @@ class AimbotApp:
         self.headshot_var = tk.DoubleVar(value=self.settings.headshot_probability)
         ttk.Entry(frame, textvariable=self.headshot_var, width=5).grid(row=row, column=1, sticky="w")
         row += 1
+        self.acquire_headshot_var = tk.BooleanVar(value=self.settings.headshot_on_acquire)
+        ttk.Checkbutton(
+            frame,
+            text="Headshot on acquire",
+            variable=self.acquire_headshot_var,
+        ).grid(row=row, column=0, columnspan=2, sticky="w")
+        row += 1
         ttk.Label(frame, text="Target select").grid(row=row, column=0, sticky="w")
         self.target_var = tk.StringVar(value=self.settings.target_select_type)
         ttk.Combobox(frame, textvariable=self.target_var, values=["fov", "distance"], width=8).grid(row=row, column=1, sticky="w")
@@ -243,6 +250,7 @@ class AimbotApp:
         self.settings.headshot_probability = float(self.headshot_var.get())
         self.settings.target_select_type = self.target_var.get()
         self.settings.smooth_speed = float(self.smooth_var.get())
+        self.settings.headshot_on_acquire = self.acquire_headshot_var.get()
 
         self.settings.grey_talon_lock_enabled = self.grey_enabled.get()
         if self.grey_key.get():


### PR DESCRIPTION
## Summary
- document `headshot_on_acquire` aimbot option
- add `headshot_on_acquire` setting to `AimbotSettings`
- force headshot for 0.4s when acquiring target after 2s idle
- expose new setting in GUI

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68415b700be8832db43c31cc9f2eb5ad