### PR TITLE
Rename GUI executable

### DIFF
--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -27,17 +27,17 @@ jobs:
           echo ${{ github.sha }} > version.txt
           
           # Build with verbose output
-          pyinstaller --log-level=INFO aimbot_gui.spec
+          pyinstaller --log-level=INFO deadunlock.spec
           
       - name: Verify executable and icon
         run: |
           # Check if executable was created
-          if (Test-Path "dist/aimbot_gui.exe") {
-              $size = (Get-Item "dist/aimbot_gui.exe").Length
+          if (Test-Path "dist/deadunlock.exe") {
+              $size = (Get-Item "dist/deadunlock.exe").Length
               Write-Output "Executable created: $size bytes"
               
               # Try to extract icon info (basic check)
-              $file = Get-Item "dist/aimbot_gui.exe"
+              $file = Get-Item "dist/deadunlock.exe"
               Write-Output "Executable details: $($file.Name) - $($file.Length) bytes"
           } else {
               Write-Error "Executable not found!"
@@ -54,6 +54,6 @@ jobs:
           tag_name: ${{ steps.vars.outputs.tag }}
           name: ${{ steps.vars.outputs.tag }}
           files: |
-            dist/aimbot_gui.exe
+            dist/deadunlock.exe
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN  }}

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ process.
 
 Builds are automatically generated on every push and published under the
 [releases](https://github.com/hmate9/deadunlock/releases). Grab the latest
-`aimbot_gui.exe` from the
+`deadunlock.exe` from the
 [latest release](https://github.com/hmate9/deadunlock/releases/latest).
 
 ## About
@@ -164,7 +164,7 @@ pip install pyinstaller
 Then create the executable with:
 
 ```bash
-pyinstaller aimbot_gui.spec
+pyinstaller deadunlock.spec
 ```
 
 The resulting `.exe` will be placed in the `dist` folder and can be run on
@@ -196,8 +196,8 @@ python -m py_compile $(git ls-files '*.py')
   - `update_checker.py` – utilities for checking GitHub for new releases.
 - `launcher.py` – entry point used when bundling the GUI with PyInstaller.
 - `offset_finder.py` – scans the game to find updated memory offsets.
-- `signature_patterns.py` – byte patterns consumed by the offset finder.
-- `aimbot_gui.spec` – PyInstaller configuration for building an executable.
+  - `signature_patterns.py` – byte patterns consumed by the offset finder.
+  - `deadunlock.spec` – PyInstaller configuration for building an executable.
 - `version.txt` – text file storing the current version string.
 - `img/` – images used in the README and GUI icons.
 

--- a/deadlock/aimbot_gui.py
+++ b/deadlock/aimbot_gui.py
@@ -26,7 +26,7 @@ from .update_checker import update_available, open_release_page
 class AimbotApp:
     def __init__(self, root: tk.Tk) -> None:
         self.root = root
-        self.root.title("DeadUnlock Aimbot")
+        self.root.title("DeadUnlock")
         self.root.geometry("750x520")
         self.root.minsize(620, 480)
         

--- a/deadunlock.spec
+++ b/deadunlock.spec
@@ -68,7 +68,7 @@ exe = EXE(
     a.binaries,
     a.datas,
     [],
-    name='aimbot_gui',
+    name='deadunlock',
     debug=False,
     bootloader_ignore_signals=False,
     strip=False,


### PR DESCRIPTION
## Summary
- change window title to **DeadUnlock**
- rename PyInstaller spec and executable output
- update README and workflow to reference `deadunlock.exe`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684efd297d94832d85b9c7289ddd72f8